### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/talens/src/app/candidate/assessment/page.tsx
+++ b/talens/src/app/candidate/assessment/page.tsx
@@ -29,7 +29,17 @@ type Plan = {
 
 type AIState = 'idle' | 'speaking' | 'listening' | 'thinking'
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+// SSRF mitigation: Only allow trusted API base URLs.
+const ALLOWED_API_BASES = [
+  "http://localhost:8000",
+  "https://api.example.com", // Replace with your real production API endpoint(s)
+  // Add other trusted endpoints here.
+];
+const ENV_API_BASE = process.env.NEXT_PUBLIC_API_URL;
+const API_BASE = 
+  typeof ENV_API_BASE === "string" && ALLOWED_API_BASES.includes(ENV_API_BASE)
+    ? ENV_API_BASE
+    : "http://localhost:8000";
 const MAX_WARNINGS = 3
 
 // AI Avatar Component


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/25](https://github.com/iyngr/ci-mock/security/code-scanning/25)

To fix this SSRF risk, you should whitelist known, trusted API base URLs rather than using the value of `process.env.NEXT_PUBLIC_API_URL` directly. Specifically:

- Create an explicit allow-list (array) of trusted API base URLs that your application recognizes and approves for outgoing requests.
- When building `API_BASE`, check the value from `process.env.NEXT_PUBLIC_API_URL` against this list; if it matches, use it. Otherwise, safely default to a hardcoded value.
- This check should happen where `API_BASE` is initialized.
- To implement, define the array of allowed URLs near the API_BASE assignment, check membership, and set `API_BASE` accordingly.
- No further changes are needed elsewhere, as the `fetch` call merely uses `API_BASE`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
