### PR TITLE
Potential fix for code scanning alert no. 21: Server-side request forgery

### DIFF
--- a/frontend/src/app/admin/report/page.tsx
+++ b/frontend/src/app/admin/report/page.tsx
@@ -77,9 +77,8 @@ export default function ReportsPage() {
             let baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
             if (!ALLOWED_API_BASE_URLS.includes(baseUrl)) {
-                console.error('Attempted to use a disallowed API base URL:', baseUrl)
-                // fallback to default safe value or throw error
-                baseUrl = 'http://localhost:8000'
+                // Instead of silently falling back, *fail loud* for SSRF safety
+                throw new Error(`Disallowed API base URL detected in configuration: "${baseUrl}". Allowed URLs: ${ALLOWED_API_BASE_URLS.join(", ")}. Refusing to make backend requests. Please fix the environment configuration.`)
             }
 
             // Fetch submissions (tests) and assessments in parallel


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/21](https://github.com/iyngr/ci-mock/security/code-scanning/21)

To remediate the SSRF risk, ensure that the `baseUrl` used in backend fetch requests is *strictly* limited to a known-safe set of URLs. Instead of silently falling back to a default value if an environment-supplied (potentially user-controlled) value isn't in the allow-list, fail fast by throwing an error or refusing to continue. This prevents the application from proceeding with an unexpected or invalid API base URL, making misconfigurations immediately obvious and visible, and removing the risk of silent SSRF vectors creeping in.

**How to fix:**  
- When building the `baseUrl`, check if the value from `process.env.NEXT_PUBLIC_API_URL` is in the allow-list.
- If it *is not* in the allow-list, throw an error and do not attempt any fetch requests using that URL.
- Remove (or make unreachable) the fallback to `'http://localhost:8000'` except possibly in a *strictly* local/development context.
- Optionally, log a *clear* and *loud* error or show a message that the server is misconfigured.
- Document (in code comments if needed) that the allow-list must be updated to include any valid deployment URLs.

**Specifics for this code:**  
- Within the `fetchReports` function, after obtaining the value for `baseUrl`, check membership in `ALLOWED_API_BASE_URLS`.
- If the `baseUrl` is not allowed, throw an exception or set an error state and return—do *not* fallback and proceed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
