### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/llm-agent/tools.py
+++ b/llm-agent/tools.py
@@ -762,5 +762,12 @@ def validate_question(question_text: str) -> dict:
         return {"status": "unique", "question_hash": question_hash}
 
     except Exception as e:
-        print(f"Error in validation: {e}")
-        return {"status": "validation_error", "error": str(e)}
+        # Log the detailed error for server-side debugging
+        try:
+            from logging_config import get_logger
+            logger = get_logger("tools.validate_question")
+            logger.error(f"Error in validation: {e}", exc_info=True)
+        except Exception:
+            print(f"Error in validation: {e}")
+        # Do not expose internal error details to the client
+        return {"status": "validation_error", "error": "A validation error occurred during question processing."}


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/12](https://github.com/iyngr/ci-mock/security/code-scanning/12)

The baseline fix is to avoid exposing the internal exception string from `llm-agent/tools.py` to the API user. Instead, the API should return a generic error message (e.g., "A validation error occurred."), while logging the original exception detail for server-side debugging. To fix the problem:

- In `llm-agent/tools.py`, update the `validate_question` function so that when catching an exception, it logs the detailed error and returns a generic message in the result dictionary's `"error"` key.
- Ensure logging of the exception uses the project logger if available, or prints as fallback.
- No changes are required in `llm-agent/main.py`, because it already logs errors and wraps unexpected exceptions in generic HTTP 500s. The main issue is the error string originating from `tools.py`.

Technically, this requires introducing either the logger (if available in `tools.py`) or a `print()` statement. We'll prefer using the logger if it's imported, else fallback to `print()` logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
