### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/llm-agent/main.py
+++ b/llm-agent/main.py
@@ -463,7 +463,11 @@ RUBRICS_DIR = Path(__file__).parent / "rubrics"
 def _load_rubric(name: str = "default") -> Dict[str, Any]:
     # Validate that the rubric file is contained within RUBRICS_DIR
     path = (RUBRICS_DIR / f"{name}.json").resolve()
-    if not str(path).startswith(str(RUBRICS_DIR.resolve())):
+    # Extra defense: forbid path separators in name (rudimentary rule)
+    if "/" in name or "\\" in name or ".." in name:
+        raise FileNotFoundError(f"Rubric '{name}' not found (invalid name)")
+    # Use robust ancestry/path check (Python >= 3.9)
+    if not path.is_relative_to(RUBRICS_DIR.resolve()):
         raise FileNotFoundError(f"Rubric '{name}' not found (invalid path)")
     if not path.exists():
         raise FileNotFoundError(f"Rubric '{name}' not found")


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/6](https://github.com/iyngr/ci-mock/security/code-scanning/6)

To robustly defend against path traversal using user-supplied `name`, we should:
1. Normalise the combined path using `pathlib.Path.resolve()` (as the code already does).
2. Instead of checking with `startswith`, use Python's path ancestry checking (`Path.is_relative_to` in >=3.9 or manual parent walking for older Python versions) to ensure the resolved path is strictly within the intended root directory (`RUBRICS_DIR`). This avoids string prefix confusion and handles possible symbolic links and other OS-level edge cases.
3. Optionally, force the filename itself to not contain any path separators, for extra defense (rejecting `/`, `\`, or `..` in `name`). 
4. No changes are needed to the endpoint argument or the import section, but we need to modify both the check and possibly the guard to use `is_relative_to`.

**Areas and lines to change**:  
- In `llm-agent/main.py`, modify lines 466-467 in `_load_rubric` to use a robust ancestry check and optionally forbid path separators in `name`.
- No new dependencies are needed; all required features are available in the Python standard library (>=3.9, otherwise manual implementation).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
