### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/llm-agent/main.py
+++ b/llm-agent/main.py
@@ -466,20 +466,20 @@ def _load_rubric(name: str = "default") -> Dict[str, Any]:
     import re
     sanitized = secure_filename(name)
     if name != sanitized:
-        raise FileNotFoundError(f"Rubric '{name}' not found (invalid name or unsafe characters)")
-    if "/" in name or "\\" in name or ".." in name or not re.fullmatch(r"[a-zA-Z0-9_\-]+", name):
-        raise FileNotFoundError(f"Rubric '{name}' not found (invalid name)")
-    # Construct and normalize the rubric file path
-    path = (RUBRICS_DIR / f"{name}.json")
+        raise FileNotFoundError(f"Rubric '{sanitized}' not found (invalid name or unsafe characters)")
+    if "/" in name or "\\" in name or ".." in name or not re.fullmatch(r"[a-zA-Z0-9_\-]+", sanitized):
+        raise FileNotFoundError(f"Rubric '{sanitized}' not found (invalid name)")
+    # Construct and normalize the rubric file path, always use sanitized name
+    rubric_path = RUBRICS_DIR / f"{sanitized}.json"
     try:
         # Python 3.9+ robust ancestry/path check
         resolved_root = RUBRICS_DIR.resolve()
-        resolved_path = path.resolve()
+        resolved_path = rubric_path.resolve()
         is_contained = resolved_path.is_relative_to(resolved_root)
     except AttributeError:
         # Compatibility: fallback for Python < 3.9. Check ancestry without using string prefix.
         resolved_root = RUBRICS_DIR.resolve()
-        resolved_path = path.resolve()
+        resolved_path = rubric_path.resolve()
         def _is_relative_to(path, root):
             # Returns True if `root` is a parent of `path` or same as path
             try:
@@ -489,10 +489,10 @@ def _load_rubric(name: str = "default") -> Dict[str, Any]:
                 return False
         is_contained = _is_relative_to(resolved_path, resolved_root)
     if not is_contained:
-        raise FileNotFoundError(f"Rubric '{name}' not found (invalid path)")
-    if not path.exists():
-        raise FileNotFoundError(f"Rubric '{name}' not found")
-    with path.open("r", encoding="utf-8") as f:
+        raise FileNotFoundError(f"Rubric '{sanitized}' not found (invalid path)")
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Rubric '{sanitized}' not found")
+    with resolved_path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/llm-agent/main.py
+++ b/llm-agent/main.py
@@ -461,11 +461,11 @@ RUBRICS_DIR = Path(__file__).parent / "rubrics"
 
 @lru_cache(maxsize=8)
 def _load_rubric(name: str = "default") -> Dict[str, Any]:
-    # Validate that the rubric file is contained within RUBRICS_DIR
-    path = (RUBRICS_DIR / f"{name}.json").resolve()
-    # Extra defense: forbid path separators in name (rudimentary rule)
+    # Extra defense: forbid path separators or traversal in name BEFORE path use
     if "/" in name or "\\" in name or ".." in name:
         raise FileNotFoundError(f"Rubric '{name}' not found (invalid name)")
+    # Validate that the rubric file is contained within RUBRICS_DIR
+    path = (RUBRICS_DIR / f"{name}.json").resolve()
     # Use robust ancestry/path check (Python >= 3.9)
     if not path.is_relative_to(RUBRICS_DIR.resolve()):
         raise FileNotFoundError(f"Rubric '{name}' not found (invalid path)")

--- a/llm-agent/main.py
+++ b/llm-agent/main.py
@@ -473,10 +473,17 @@ def _load_rubric(name: str = "default") -> Dict[str, Any]:
         resolved_path = path.resolve()
         is_contained = resolved_path.is_relative_to(resolved_root)
     except AttributeError:
-        # Compatibility: fallback for Python < 3.9
-        resolved_root = str(RUBRICS_DIR.resolve())
-        resolved_path = str(path.resolve())
-        is_contained = os.path.commonprefix([resolved_path, resolved_root]) == resolved_root
+        # Compatibility: fallback for Python < 3.9. Check ancestry without using string prefix.
+        resolved_root = RUBRICS_DIR.resolve()
+        resolved_path = path.resolve()
+        def _is_relative_to(path, root):
+            # Returns True if `root` is a parent of `path` or same as path
+            try:
+                path.relative_to(root)
+                return True
+            except ValueError:
+                return False
+        is_contained = _is_relative_to(resolved_path, resolved_root)
     if not is_contained:
         raise FileNotFoundError(f"Rubric '{name}' not found (invalid path)")
     if not path.exists():


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/6](https://github.com/iyngr/ci-mock/security/code-scanning/6)

To robustly ensure user input is not used to access files outside the intended directory, apply all validation *before* constructing or resolving the potentially dangerous path. Specifically:

- Move the validation for forbidden characters (`/`, `\`, `..`) on `name` *before* using it in path operations.
- Normalize the joined path using `.resolve()` and check that it is a descendant of `RUBRICS_DIR` (using `.is_relative_to`).
- Only after *all* validation checks pass, proceed to check existence and open the file.
- Optionally, further sanitize `name` using a strict regex or a function like `werkzeug.utils.secure_filename` (if we had access to it), but with the above steps, the risk is significantly reduced using only the standard library.

**Files/regions/lines to change:**  
- In `llm-agent/main.py` (`_load_rubric`), move the name validation check before constructing or resolving the path, and consider replacing the current `".." in name` check with a stricter check (e.g. reject any path components except alphanumerics and a safe set like '_', '-').

**Needed:**  
- No new imports are necessary for these basic checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
