### PR TITLE
Potential fix for code scanning alert no. 32: Server-side request forgery

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,7 +1,24 @@
 // Centralized API client wrapper
 // Uses NEXT_PUBLIC_API_URL and automatically attaches Authorization header if candidateToken present.
 
-export const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+// List of trusted API base URLs. Adjust as required for your deployment environments.
+const allowedApiBases = [
+    'http://localhost:8000',
+    'https://api.myapp.com',
+    'https://staging-api.myapp.com'
+];
+
+// Validate that the configured API URL is allowed
+function getSafeApiBase(): string {
+    const envBase = process.env.NEXT_PUBLIC_API_URL || '';
+    if (allowedApiBases.includes(envBase)) {
+        return envBase;
+    }
+    return 'http://localhost:8000';
+}
+
+export const apiBase = getSafeApiBase();
 
 export interface ApiError extends Error {
     status?: number;


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/32](https://github.com/iyngr/ci-mock/security/code-scanning/32)

To fix this vulnerability, you need to ensure that the value of `apiBase` (from `NEXT_PUBLIC_API_URL`) can't be set arbitrarily or used for SSRF. The best practice is to validate this base URL against an allowlist of acceptable hosts, protocols, and/or origins before using it to construct outgoing requests. This can be done during module initialization.

A good solution here is to define a list of trusted base URLs (for example, as an array of string literals or regexes that match only your allowed API hosts). When initializing `apiBase`, check the value against this list; if it is not in the list, default to `http://localhost:8000` or throw an error.

All required changes are within the shown snippet in `frontend/src/lib/apiClient.ts`:
- Add a list of allowed origins or base URLs near the top of the file.
- Replace the assignment of `apiBase` on line 4 with a function that validates the environment variable value.
- Optionally, add a helper function (or inline code) that checks the URL against the list.
- No new dependencies are strictly needed, as standard JS/TS capabilities suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
