### PR TITLE
Potential fix for code scanning alert no. 10: Full server-side request forgery

### DIFF
--- a/auto-submit/function_app.py
+++ b/auto-submit/function_app.py
@@ -119,21 +119,12 @@ ALLOWED_SCORING_ENDPOINTS = [
     "https://ai.yourcompany.com/score",
     "https://prod.scoring.service/score",
 ]
-ALLOWED_SCORING_HOSTNAMES = [
-    "ai.yourcompany.com",
-    "prod.scoring.service",
-]
+# ALLOWED_SCORING_HOSTNAMES removed for SSRF hardening
 
 def is_allowed_endpoint(url):
     try:
-        parsed = urllib.parse.urlparse(url)
-        # Check exact allowed endpoints (including full URL)
-        if url in ALLOWED_SCORING_ENDPOINTS:
-            return True
-        # Otherwise, only allow HTTPS URLs to approved hostnames
-        if parsed.scheme == "https" and parsed.hostname in ALLOWED_SCORING_HOSTNAMES:
-            return True
-        return False
+        # Only allow exact full URLs. No host-based allowlisting.
+        return url in ALLOWED_SCORING_ENDPOINTS
     except Exception:
         return False
 
@@ -150,9 +141,9 @@ async def trigger_ai_scoring(submission: dict):
         if not scoring_endpoint:
             logging.warning("AI_SCORING_ENDPOINT not configured, skipping AI scoring")
             return
-        # Validate the scoring endpoint against allowlist
+        # Ensure only exact full URLs from allowlist are allowed.
         if not is_allowed_endpoint(scoring_endpoint):
-            logging.error(f"Configured AI_SCORING_ENDPOINT '{scoring_endpoint}' is not in the allowed list. Skipping AI scoring trigger.")
+            logging.error(f"Configured AI_SCORING_ENDPOINT '{scoring_endpoint}' is not an exact match in the allowed endpoint list. Skipping AI scoring trigger.")
             return
         
         


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/10](https://github.com/iyngr/ci-mock/security/code-scanning/10)

The best way to fix this problem is to *eliminate all dynamic (including environment variable) control over outbound URLs, except for a strict allowlist of full URLs hardcoded in source control.* The function already implements an allowlist and a check via `is_allowed_endpoint`, but that allowlist currently supports both full URLs and plain hostnames, which is less secure. To increase security:

- Only accept outbound destination URLs that exactly match a predefined list of approved endpoints (no hostname-level allowlist; only full URLs should be allowed).
- Remove support for plain host validation to prevent attackers from using misleading subdomains or obscure host tricks.
- If there is a need for environments (e.g., dev/prod), explicitly enumerate acceptable full URLs for each.
- Avoid directly using an environment variable for the destination URL; instead, use a *fixed* constant, or use the env var *solely* as a key to select from a mapping of allowed endpoints (e.g., `"dev"`, `"prod"`), never as a full URL.

Thus, in `trigger_ai_scoring`, you should:
- Change the allowlist (`ALLOWED_SCORING_ENDPOINTS`) to contain only full (and exact) URLs for allowed scoring endpoints.
- Remove the `ALLOWED_SCORING_HOSTNAMES` list and any related logic.
- In `is_allowed_endpoint()`, only allow requests to exactly those URLs present in `ALLOWED_SCORING_ENDPOINTS`.
- Optionally, instead of passing the full URL in the environment variable, pass a logical name (like "prod", "dev") and map that to allowed endpoints in code.

If your application *must* allow specifying the full URL via an env var, then restrict it by warning and failing at startup if the env var is set to an unallowed value.

**Files to update:**
- `auto-submit/function_app.py`: Update the allowlist, the `is_allowed_endpoint` function, and the retrieval of the endpoint URL accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
