### PR TITLE
Potential fix for code scanning alert no. 34: Full server-side request forgery

### DIFF
--- a/scripts/cosmos_vector_test.py
+++ b/scripts/cosmos_vector_test.py
@@ -50,8 +50,11 @@ async def embed_text(text: str):
         # 'llm-agent.yourcompany.com',
         # 'trusted-agent.example.com',
     ]
-    # Alternatively: allow only HTTPS on specific domains
+    # SSRF protection: refuse to call agent unless allowed hosts are specified
     if agent:
+        if not ALLOWED_AGENT_HOSTNAMES:
+            print("SSRF protection: Refusing to call agent because ALLOWED_AGENT_HOSTNAMES is empty. Please configure trusted agent endpoints.")
+            return None
         parsed = urlparse(agent)
         # Only allow agent endpoints explicitly whitelisted
         if not parsed.hostname or parsed.hostname not in ALLOWED_AGENT_HOSTNAMES:


### PR DESCRIPTION
Potential fix for [https://github.com/iyngr/ci-mock/security/code-scanning/34](https://github.com/iyngr/ci-mock/security/code-scanning/34)

To fix the SSRF vulnerability, ensure that untrusted user input (here, the environment variable `LLM_AGENT_URL`) cannot be used to construct a request URL unless its destination is strictly validated against a hardcoded allow-list. Instead of leaving `ALLOWED_AGENT_HOSTNAMES` empty, apply a preventative check that refuses all agent calls unless the list is explicitly populated. Additionally, update the logic so the allowed hostnames must be non-empty, and any attempt to call an agent when the list is empty should result in a hard refusal with an informative error or warning to the user. This reduces the risk of insecure default configurations where SSRF mitigation is not enforced.

Specifically, in scripts/cosmos_vector_test.py, within the `embed_text` function:
- On lines 48-52: Make clear the list must be populated and refuse if empty.
- On lines 54-94: If `ALLOWED_AGENT_HOSTNAMES` is empty, do not attempt any agent call.
- Optionally, print a warning indicating SSRF protection is enforced.
- No changes to imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
